### PR TITLE
[9.0]Fix demand estimate domains

### DIFF
--- a/ddmrp/models/stock_warehouse_orderpoint.py
+++ b/ddmrp/models/stock_warehouse_orderpoint.py
@@ -391,8 +391,8 @@ class StockWarehouseOrderpoint(models.Model):
     def _past_demand_estimate_domain(self, date_from, date_to, locations):
         return [('location_id', 'in', locations.ids),
                 ('product_id', '=', self.product_id.id),
-                '|', ('date_range_id.date_start', '>=', date_from),
-                ('date_range_id.date_end', '<=', date_to)]
+                ('date_range_id.date_start', '<=', date_to),
+                ('date_range_id.date_end', '>=', date_from)]
 
     @api.model
     def _past_moves_domain(self, date_from, locations):
@@ -434,8 +434,8 @@ class StockWarehouseOrderpoint(models.Model):
     def _future_demand_estimate_domain(self, date_from, date_to, locations):
         return [('location_id', 'in', locations.ids),
                 ('product_id', '=', self.product_id.id),
-                '|', ('date_range_id.date_start', '>=', date_from),
-                ('date_range_id.date_end', '<=', date_to)]
+                ('date_range_id.date_start', '<=', date_to),
+                ('date_range_id.date_end', '>=', date_from)]
 
     @api.model
     def _future_moves_domain(self, date_to, locations):


### PR DESCRIPTION
Hello,
I think there is problem with the domain used to take the estimation into account, for the adu calculation.
For a classic use, I guess it work but it is not optimized : imagine you have weekly estimates during 2 full year : 01/01/2017 - 31/12/2018.
You can to base you ADU computation on future estimate, with 30 days horizon.
The present code will return all 104 estimates ! The method in stock_demande_estimate : https://github.com/OCA/stock-logistics-warehouse/blob/9.0/stock_demand_estimate/models/stock_demand_estimate.py#L71
will then do the job and mainly return 0 quantity for out of range estimate, so the final result is correct, but not optimized.

Another case does not work. Imagine you have a monthly estimate : 
01/02/2018 - 28/02/2018
You want to base your ADU computatioon on future estimate with 7 days horizon. so from 19/02/2018 to 26/02/2018.
With the present code, it won't return the estimate.

This last example is does not work with stock_demande_estimate either. Once you review this PR, I will make another PR to fix stock_demande_estimate in OCA.
What do you think?