### PR TITLE
[10.0] fix has_mto_rule in mrp.bom

### DIFF
--- a/ddmrp/__manifest__.py
+++ b/ddmrp/__manifest__.py
@@ -24,7 +24,6 @@
         "stock_orderpoint_manual_procurement",
         "stock_demand_estimate",
         "web_widget_bokeh_chart",
-        "mrp_mto_with_stock",
         "base_cron_exclusion",
         "web_tree_many2one_clickable",
     ],

--- a/ddmrp/views/mrp_bom_view.xml
+++ b/ddmrp/views/mrp_bom_view.xml
@@ -8,6 +8,13 @@
         <field name="model">mrp.bom</field>
         <field name="inherit_id" ref="mrp.mrp_bom_form_view"/>
         <field name="arch" type="xml">
+            <sheet position="before">
+                <field name="has_mto_rule_exception" invisible="True"/>
+                <div class="alert alert-danger alert-dismissable" role="alert" style="margin-bottom:0px;"
+                     attrs="{'invisible':[('has_mto_rule_exception','=', False)]}">
+                    <bold><field name="has_mto_rule_exception_msg" readonly="True"/></bold>
+                </div>
+            </sheet>
             <field name="routing_id" position="before">
                 <field name="is_buffered"/>
                 <field name="has_mto_rule"/>
@@ -19,6 +26,15 @@
                 <field name="has_mto_rule"/>
                 <field name="orderpoint_id"/>
                 <field name="dlt"/>
+                <field name="has_mto_rule_exception" invisible="1"/>
+                <button string="MTO Exception"
+                        attrs="{'invisible': [('has_mto_rule_exception', '=', False)]}"
+                        name="action_mto_rule_exception"
+                        type="object"
+                        icon="fa-exclamation-triangle"/>
+            </xpath>
+            <xpath expr="//field[@name='bom_line_ids']/tree" position="attributes">
+                <attribute name="decoration-danger">has_mto_rule_exception is True</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
it was incorrect to use module 'mrp_mto_with_stock'.
In the context of ddmrp we should not make reservations, neither in pickings nor in manufacturing orders.
In order to know if BOM and BOM lines are MTO or buffered, this PR looks into the routes and associated pull rules. When there's a mix of mts/mto pull rules for the location indicated in the bom warning notifications are displayed, so that the user can take action.

@max3903 @guewen we'll need to forward-port this to v11 when it lands into v10.

cc @lreficent 